### PR TITLE
feat: capture logs

### DIFF
--- a/alloy/laravel-logs.alloy
+++ b/alloy/laravel-logs.alloy
@@ -1,0 +1,38 @@
+// ##ddev-generated
+
+/**
+ * This file contains the pipeline for Laravel logs.
+ * We map the laravel path in a docker-compose file, then use "local.file_match" to read them.
+ *
+ * 'local.file_match' discovers files on the local filesystem using glob patterns and the doublestar library.
+ * @See https://grafana.com/docs/alloy/latest/reference/components/local/local.file_match/
+ */
+local.file_match "laravel_logs" {
+  path_targets = [{
+    "__path__" = "/var/log/laravel/**/*.log",
+    "service_name" = "laravel",
+  }]
+  sync_period = "10s"
+}
+
+/**
+ * loki.source.file reads log entries from files and forwards them to other loki.* components.
+ * @See https://grafana.com/docs/alloy/latest/reference/components/loki/loki.source.file/
+ */
+loki.source.file "laravel_logs" {
+  targets = local.file_match.laravel_logs.targets
+  forward_to = [loki.process.laravel_multiline.receiver]
+}
+
+/**
+ * Parses multiline Laravel logs.
+ * Laravel log entries typically start with a timestamp like: [2024-05-19 14:22:31]
+ */
+loki.process "laravel_multiline" {
+  stage.multiline {
+    firstline = "^\\[\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}\\]"
+    max_wait_time   = "3s"
+  }
+
+  forward_to = [loki.write.default.receiver]
+}

--- a/alloy/otelcol.alloy
+++ b/alloy/otelcol.alloy
@@ -2,10 +2,11 @@
 
 otelcol.receiver.otlp "default" {
   http {
-    endpoint="alloy:4318"
+    endpoint="grafana-alloy:4318"
   }
 
   output {
+    logs  = [otelcol.processor.batch.default.input]
     traces  = [otelcol.processor.batch.default.input]
   }
 }
@@ -16,6 +17,7 @@ otelcol.receiver.otlp "default" {
  */
 otelcol.processor.batch "default" {
   output {
+    logs  = [otelcol.exporter.loki.default.input]
     traces  = [otelcol.connector.spanlogs.default.input, otelcol.exporter.otlphttp.tempo.input]
   }
 }
@@ -59,7 +61,7 @@ otelcol.exporter.loki "default" {
 
 otelcol.exporter.otlphttp "tempo" {
     client {
-        endpoint = "http://tempo:4318"
+        endpoint = "http://grafana-tempo:4318"
         tls {
             insecure             = true
             insecure_skip_verify = true

--- a/alloy/otelcol.alloy
+++ b/alloy/otelcol.alloy
@@ -28,14 +28,13 @@ otelcol.processor.batch "default" {
  */
 otelcol.connector.spanlogs "default" {
   roots              = true
+  spans              = true
   events             = true
-  labels             = ["attribute1", "res_attribute1"]
-  span_attributes    = ["attribute1"]
-  process_attributes = ["res_attribute1"]
+  labels             = ["srv", "tid"]
   event_attributes   = ["log.severity", "log.message"]
 
   overrides {
-    service_key = "service.key"
+    service_key = "srv"
   }
 
   output {
@@ -43,11 +42,37 @@ otelcol.connector.spanlogs "default" {
   }
 }
 
+/*
+ * 'otelcol.processor.attributes' accepts telemetry data from other otelcol components and modifies attributes of a span, log, or metric.
+ * @See https://grafana.com/docs/alloy/latest/reference/components/otelcol/otelcol.processor.attributes/
+ */
 otelcol.processor.attributes "default" {
+  // Extract app name from service.name attribute
+  action {
+    key = "service.name"
+    from_attribute = "srv"
+    action = "upsert"
+  }
+
+  // Extract app name from service.name attribute
+  action {
+    key = "app"
+    from_attribute = "service.name"
+    action = "upsert"
+  }
+
+  // Extract app name from service.name attribute
+  action {
+    key = "app"
+    from_attribute = "service.name"
+    action = "upsert"
+  }
+
+  // Generate loki labels from OpenTelemetry attributes
   action {
     key = "loki.attribute.labels"
     action = "insert"
-    value = "attribute1"
+    value = "service.name,app"  // comma separated list
   }
 
   output {

--- a/docker-compose.laravel-logs.yaml
+++ b/docker-compose.laravel-logs.yaml
@@ -1,6 +1,6 @@
 ##ddev-generated
 services:
-  # Map the default Larvael logs folder into Grafana Alloy.
+  # Map the default Laravel logs folder into Grafana Alloy.
   # Then we use 'alloy/laravel-logs.alloy' to parse the file and send it for processing.
   grafana-alloy:
     volumes:

--- a/docker-compose.laravel-logs.yaml
+++ b/docker-compose.laravel-logs.yaml
@@ -1,0 +1,7 @@
+##ddev-generated
+services:
+  # Map the default Larvael logs folder into Grafana Alloy.
+  # Then we use 'alloy/laravel-logs.alloy' to parse the file and send it for processing.
+  grafana-alloy:
+    volumes:
+      - ../storage/logs/:/var/log/laravel

--- a/install.yaml
+++ b/install.yaml
@@ -4,6 +4,7 @@ project_files:
   - config.site-metrics-laravel.yaml
   - docker-compose.laravel-logs.yaml
   - alloy/laravel-logs.alloy
+  - alloy/otelcol.alloy
 
 post_install_actions:
   - #ddev-description:Restart to activate PHP module

--- a/install.yaml
+++ b/install.yaml
@@ -8,6 +8,7 @@ post_install_actions:
   - ddev restart
   - #ddev-description:Add required composer packages
   - ddev composer require open-telemetry/sdk open-telemetry/opentelemetry-auto-laravel open-telemetry/exporter-otlp --dev
+  - ddev composer require open-telemetry/opentelemetry-logger-monolog --dev
   - ddev composer config allow-plugins.php-http/discovery true
   - #ddev-nodisplay
     #ddev-description:Set default environment variables

--- a/install.yaml
+++ b/install.yaml
@@ -2,6 +2,8 @@ name: site-metrics-laravel
 
 project_files:
   - config.site-metrics-laravel.yaml
+  - docker-compose.laravel-logs.yaml
+  - alloy/laravel-logs.alloy
 
 post_install_actions:
   - #ddev-description:Restart to activate PHP module

--- a/install.yaml
+++ b/install.yaml
@@ -14,9 +14,10 @@ post_install_actions:
   - ddev dotenv set .ddev/.env.web --otel-php-autoload-enabled=true > /dev/null 2>&1
   - ddev dotenv set .ddev/.env.web --otel-service-name=laravel > /dev/null 2>&1
   - ddev dotenv set .ddev/.env.web --otel-metric-exporter=none > /dev/null 2>&1
-  - ddev dotenv set .ddev/.env.web --otel-logs-exporter=none > /dev/null 2>&1
+  - ddev dotenv set .ddev/.env.web --otel-logs-exporter="otlp" > /dev/null 2>&1
   - ddev dotenv set .ddev/.env.web --otel-traces-exporter="otlp" > /dev/null 2>&1
   - ddev dotenv set .ddev/.env.web --otel-exporter-otlp-traces-endpoint="http://grafana-alloy:4318/v1/traces" > /dev/null 2>&1
+  - ddev dotenv set .ddev/.env.web --otel-exporter-otlp-logs-endpoint="http://grafana-alloy:4318/v1/logs" > /dev/null 2>&1
   # - ddev dotenv set .ddev/.env.web --otel-traces-exporter=console > /dev/null 2>&1
 
 ddev_version_constraint: '>= v1.24.3'

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -189,6 +189,42 @@ install_laravel() {
   assert_output --partial '"body":"hello world"'
 }
 
+@test "it can collect logs via parsing the Laravel log file" {
+  set -eu -o pipefail
+
+  install_laravel
+
+  echo "# ddev add-on get tyler36/ddev-site-metrics with project ${PROJNAME} in $(pwd)" >&3
+  run ddev add-on get "tyler36/ddev-site-metrics"
+  assert_success
+
+  echo "# ddev add-on get ${DIR} with project ${PROJNAME} in $(pwd)" >&3
+  run ddev add-on get "${DIR}"
+  assert_success
+
+  run ddev restart -y
+  assert_success
+
+  # Access site to generate at least 1 extracted log entry.
+  run ddev artisan tinker --execute='\Illuminate\Support\Facades\Log::info("hello world")'
+  assert_success
+  # Wait for an arbitrary amount of time for the trace to propagate.
+  sleep 10
+
+  run ddev exec curl -G http://grafana-loki:3100/loki/api/v1/query_range \
+    --data-urlencode 'query={service_name="laravel"}' \
+    --data-urlencode 'start='$(($(date +%s%N) - 3600 * 1_000_000_000)) \
+    --data-urlencode 'end='$(date +%s%N) \
+    --data-urlencode 'limit=1000' | jq -r '.data.result[].values[][1]'
+  assert_success
+
+  # Grafana Loki uses Trace discovery through logs; the message is extracted into the body.
+  assert_output --partial '"body":"hello world"'
+
+  # Grafana Loki can parse the default Laravel log file; it displays the raw log level and message.
+  assert_output --partial 'local.INFO: hello world'
+}
+
 # bats test_tags=release
 @test "install from release" {
   set -eu -o pipefail

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -213,7 +213,7 @@ install_laravel() {
   run ddev artisan tinker --execute='\Illuminate\Support\Facades\Log::info("hello world")'
   assert_success
   # Wait for an arbitrary amount of time for the trace to propagate.
-  sleep 10
+  sleep 20
 
   run ddev exec curl -G http://grafana-loki:3100/loki/api/v1/query_range \
     --data-urlencode 'query={service_name="laravel"}' \

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -56,6 +56,11 @@ teardown() {
   [ "${TESTDIR}" != "" ] && rm -rf ${TESTDIR}
 }
 
+setup_project() {
+  install_laravel
+  ddev addon get tyler36/ddev-site-metrics
+}
+
 install_laravel() {
   ddev config --project-type=laravel --docroot=public
   ddev start
@@ -67,7 +72,7 @@ install_laravel() {
 @test "install from directory" {
   set -eu -o pipefail
 
-  install_laravel
+  setup_project
 
   echo "# ddev add-on get ${DIR} with project ${PROJNAME} in $(pwd)" >&3
   run ddev add-on get "${DIR}"
@@ -81,7 +86,7 @@ install_laravel() {
 @test "it can collect traces" {
   set -eu -o pipefail
 
-  install_laravel
+  setup_project
 
   echo "# ddev add-on get ${DIR} with project ${PROJNAME} in $(pwd)" >&3
   run ddev add-on get "${DIR}"
@@ -132,7 +137,7 @@ install_laravel() {
 @test "it can collect logs" {
   set -eu -o pipefail
 
-  install_laravel
+  setup_project
 
   echo "# ddev add-on get ${DIR} with project ${PROJNAME} in $(pwd)" >&3
   run ddev add-on get "${DIR}"
@@ -159,7 +164,7 @@ install_laravel() {
 @test "it can collect logs via OTEL collection" {
   set -eu -o pipefail
 
-  install_laravel
+  setup_project
 
   echo "# ddev add-on get tyler36/ddev-site-metrics with project ${PROJNAME} in $(pwd)" >&3
   run ddev add-on get "tyler36/ddev-site-metrics"
@@ -192,7 +197,7 @@ install_laravel() {
 @test "it can collect logs via parsing the Laravel log file" {
   set -eu -o pipefail
 
-  install_laravel
+  setup_project
 
   echo "# ddev add-on get tyler36/ddev-site-metrics with project ${PROJNAME} in $(pwd)" >&3
   run ddev add-on get "tyler36/ddev-site-metrics"
@@ -228,6 +233,9 @@ install_laravel() {
 # bats test_tags=release
 @test "install from release" {
   set -eu -o pipefail
+
+  setup_project
+
   echo "# ddev add-on get ${GITHUB_REPO} with project ${PROJNAME} in $(pwd)" >&3
   run ddev add-on get "${GITHUB_REPO}"
   assert_success

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -222,9 +222,6 @@ install_laravel() {
     --data-urlencode 'limit=1000' | jq -r '.data.result[].values[][1]'
   assert_success
 
-  # Grafana Loki uses Trace discovery through logs; the message is extracted into the body.
-  assert_output --partial '"body":"hello world"'
-
   # Grafana Loki can parse the default Laravel log file; it displays the raw log level and message.
   assert_output --partial 'local.INFO: hello world'
 }

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -181,17 +181,16 @@ install_laravel() {
   run ddev artisan tinker --execute='\Illuminate\Support\Facades\Log::info("hello world")'
   assert_success
   # Wait for an arbitrary amount of time for the trace to propagate.
-  sleep 10
+  sleep 5
 
   run ddev exec curl -G http://grafana-loki:3100/loki/api/v1/query_range \
     --data-urlencode 'query={service_name="laravel"}' \
     --data-urlencode 'start='$(($(date +%s%N) - 3600 * 1000000000)) \
     --data-urlencode 'end='$(date +%s%N) \
-    --data-urlencode 'limit=1000' | jq -r '.data.result[].values[][1]'
+    --data-urlencode 'limit=1000'
   assert_success
-
   # Grafana Loki uses Trace discovery through logs; the message is extracted into the body.
-  assert_output --partial '"body":"hello world"'
+  assert_output --partial '\"body\":\"hello world\"'
 }
 
 @test "it can collect logs via parsing the Laravel log file" {

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -185,7 +185,7 @@ install_laravel() {
 
   run ddev exec curl -G http://grafana-loki:3100/loki/api/v1/query_range \
     --data-urlencode 'query={service_name="laravel"}' \
-    --data-urlencode 'start='$(($(date +%s%N) - 3600 * 1_000_000_000)) \
+    --data-urlencode 'start='$(($(date +%s%N) - 3600 * 1000000000)) \
     --data-urlencode 'end='$(date +%s%N) \
     --data-urlencode 'limit=1000' | jq -r '.data.result[].values[][1]'
   assert_success
@@ -218,7 +218,7 @@ install_laravel() {
 
   run ddev exec curl -G http://grafana-loki:3100/loki/api/v1/query_range \
     --data-urlencode 'query={service_name="laravel"}' \
-    --data-urlencode 'start='$(($(date +%s%N) - 3600 * 1_000_000_000)) \
+    --data-urlencode 'start='$(($(date +%s%N) - 3600 * 1000000000)) \
     --data-urlencode 'end='$(date +%s%N) \
     --data-urlencode 'limit=1000' | jq -r '.data.result[].values[][1]'
   assert_success

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -219,7 +219,7 @@ install_laravel() {
     --data-urlencode 'query={service_name="laravel"}' \
     --data-urlencode 'start='$(($(date +%s%N) - 3600 * 1000000000)) \
     --data-urlencode 'end='$(date +%s%N) \
-    --data-urlencode 'limit=1000' | jq -r '.data.result[].values[][1]'
+    --data-urlencode 'limit=1000'
   assert_success
 
   # Grafana Loki can parse the default Laravel log file; it displays the raw log level and message.


### PR DESCRIPTION
## The Issue

Currently, the ddev Grafana stack add-on only supports collecting traces and metrics from Laravel applications.  There is no built-in mechanism to collect and visualize application logs, making it difficult to troubleshoot issues and monitor application behavior.

## How This PR Solves The Issue

This pull request adds the necessary components and configurations to collect Laravel logs and send them to Loki for storage and querying. 

## Manual Testing Instructions

1. Install addon

```bash
ddev add-on get https://github.com/tyler36/ddev-site-metrics-laravel/tarball/feat--collect-Laravel-logs
ddev restart
```

2.  **Generate Laravel Logs**
    * Access the site `ddev launch` to generate some initial logs.

3. **Verify Logs in Grafana:**
    *  Acces Grafana via `ddev launch :3000/a/grafana-lokiexplore-app/explore` to query logs directly.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
