### PR TITLE
test: confirms traces are processed

### DIFF
--- a/install.yaml
+++ b/install.yaml
@@ -16,7 +16,7 @@ post_install_actions:
   - ddev dotenv set .ddev/.env.web --otel-metric-exporter=none > /dev/null 2>&1
   - ddev dotenv set .ddev/.env.web --otel-logs-exporter=none > /dev/null 2>&1
   - ddev dotenv set .ddev/.env.web --otel-traces-exporter="otlp" > /dev/null 2>&1
-  - ddev dotenv set .ddev/.env.web --otel-exporter-otlp-traces-endpoint="http://alloy:4318/v1/traces" > /dev/null 2>&1
+  - ddev dotenv set .ddev/.env.web --otel-exporter-otlp-traces-endpoint="http://grafana-alloy:4318/v1/traces" > /dev/null 2>&1
   # - ddev dotenv set .ddev/.env.web --otel-traces-exporter=console > /dev/null 2>&1
 
 ddev_version_constraint: '>= v1.24.3'

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -100,6 +100,35 @@ install_laravel() {
   ddev logs -s web | \grep --color=auto '"service.name": "laravel"'
 }
 
+@test "it can collect traces through Grafana workflow" {
+  set -eu -o pipefail
+
+  install_laravel
+
+  echo "# ddev add-on get tyler36/ddev-site-metrics with project ${PROJNAME} in $(pwd)" >&3
+  run ddev add-on get "tyler36/ddev-site-metrics"
+  assert_success
+
+  echo "# ddev add-on get ${DIR} with project ${PROJNAME} in $(pwd)" >&3
+  run ddev add-on get "${DIR}"
+  assert_success
+
+  run ddev restart -y
+  assert_success
+
+  # Access site to generate at least 1 extracted log entry.
+  run curl -sfI https://${PROJNAME}.ddev.site
+  assert_success
+  # Wait for an arbitrary amount of time for the trace to propagate.
+  sleep 15
+
+  # Grafana Loki uses Trace discovery through logs
+  export LOKI_SERVER="http://grafana-loki:3100"
+  run ddev exec curl -s "${LOKI_SERVER}/loki/api/v1/query" --data-urlencode 'query=sum(rate({service_name="laravel"}[1m])) by (level)'
+  assert_success
+  assert_output --partial '"totalEntriesReturned":1'
+}
+
 # bats test_tags=release
 @test "install from release" {
   set -eu -o pipefail

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -106,7 +106,9 @@ install_laravel() {
   echo "# ddev add-on get ${GITHUB_REPO} with project ${PROJNAME} in $(pwd)" >&3
   run ddev add-on get "${GITHUB_REPO}"
   assert_success
+
   run ddev restart -y
   assert_success
+
   health_checks
 }


### PR DESCRIPTION
## The Issue

The `otel-exporter-otlp-traces-endpoint` in `.ddev/.env.web` was pointing to a non-existent service `alloy` rather than the correct Grafana Alloy service `grafana-alloy`.

Requires https://github.com/tyler36/ddev-site-metrics/releases/tag/v0.5.3

## How This PR Solves The Issue

This PR updates the configuration to correctly point to the `grafana-alloy` instance, ensuring that traces are properly collected. In addition, this PR adds a test to ensure grafana can scrape traces from ddev.

## Manual Testing Instructions

1.  **Follow DDEV quickstart for a [Laravel Project](https://ddev.readthedocs.io/en/stable/users/quickstart/#laravel)** 

```shell
mkdir my-laravel-site && cd my-laravel-site
ddev config --project-type=laravel --docroot=public
ddev start
ddev composer create-project "laravel/laravel:^12"
ddev launch
```

2.  **Install ddev-site-metrics addon:** 

```shell
ddev addon get tyler36/ddev-site-metrics
```

3.  **Install this PR:** 

```shell
ddev addon get https://github.com/tyler36/ddev-site-metrics-laravel/tarball/update-container-names
```

4.  **Restart DDEV:** `ddev restart`
5.  **Access the site to trigger:** `ddev launch`
6.  **Verify traces are being exported:**
    1.  `ddev exec curl -s "http://grafana-loki:3100/loki/api/v1/query" --data-urlencode 'query=sum(rate({service_name="laravel"}[1m])) by (level)'`
    2.  Verify that `totalEntriesReturned` is at least 1.
7. ** Access Grafana UI to verify trace is available.

```shell
ddev launch :3000/a/grafana-exploretraces-app/explore
```
## Automated Testing Overview

BATS test `it can collect traces through Grafana workflow` included to automate check.

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
