### PR TITLE
feat: default to GRPC protocol

### DIFF
--- a/alloy/otelcol.alloy
+++ b/alloy/otelcol.alloy
@@ -1,6 +1,9 @@
 // ##ddev-generated
 
 otelcol.receiver.otlp "default" {
+  grpc {
+    endpoint="grafana-alloy:4317"
+  }
   http {
     endpoint="grafana-alloy:4318"
   }
@@ -18,7 +21,7 @@ otelcol.receiver.otlp "default" {
 otelcol.processor.batch "default" {
   output {
     logs  = [otelcol.exporter.loki.default.input]
-    traces  = [otelcol.connector.spanlogs.default.input, otelcol.exporter.otlphttp.tempo.input]
+    traces  = [otelcol.connector.spanlogs.default.input, otelcol.exporter.otlp.tempo.input]
   }
 }
 
@@ -84,6 +87,24 @@ otelcol.exporter.loki "default" {
   forward_to = [loki.write.default.receiver]
 }
 
+/**
+ * 'otelcol.exporter.otlp' accepts telemetry data from other otelcol components and writes them over the network using the OTLP gRPC protocol.
+ * @See https://grafana.com/docs/alloy/latest/reference/components/otelcol/otelcol.exporter.otlp/
+ */
+otelcol.exporter.otlp "tempo" {
+    client {
+        endpoint = "grafana-tempo:4317"
+        tls {
+            insecure             = true
+            insecure_skip_verify = true
+        }
+    }
+}
+
+/**
+ * 'otelcol.exporter.otlphttp' accepts telemetry data from other otelcol components and writes them over the network using the OTLP HTTP protocol.
+ * @See https://grafana.com/docs/alloy/latest/reference/components/otelcol/otelcol.exporter.otlphttp/
+ */
 otelcol.exporter.otlphttp "tempo" {
     client {
         endpoint = "http://grafana-tempo:4318"

--- a/config.site-metrics-laravel.yaml
+++ b/config.site-metrics-laravel.yaml
@@ -1,2 +1,2 @@
 ##ddev-generated
-webimage_extra_packages: ["php${DDEV_PHP_VERSION}-opentelemetry"]
+webimage_extra_packages: ["php${DDEV_PHP_VERSION}-opentelemetry", "php${DDEV_PHP_VERSION}-grpc"]

--- a/install.yaml
+++ b/install.yaml
@@ -10,7 +10,7 @@ post_install_actions:
   - #ddev-description:Restart to activate PHP module
   - ddev restart
   - #ddev-description:Add required composer packages
-  - ddev composer require open-telemetry/sdk open-telemetry/opentelemetry-auto-laravel open-telemetry/exporter-otlp --dev
+  - ddev composer require open-telemetry/sdk open-telemetry/opentelemetry-auto-laravel open-telemetry/exporter-otlp open-telemetry/transport-grpc --dev
   - ddev composer require open-telemetry/opentelemetry-logger-monolog --dev
   - ddev composer config allow-plugins.php-http/discovery true
   - #ddev-nodisplay
@@ -20,8 +20,7 @@ post_install_actions:
   - ddev dotenv set .ddev/.env.web --otel-metric-exporter=none > /dev/null 2>&1
   - ddev dotenv set .ddev/.env.web --otel-logs-exporter="otlp" > /dev/null 2>&1
   - ddev dotenv set .ddev/.env.web --otel-traces-exporter="otlp" > /dev/null 2>&1
-  - ddev dotenv set .ddev/.env.web --otel-exporter-otlp-traces-endpoint="http://grafana-alloy:4318/v1/traces" > /dev/null 2>&1
-  - ddev dotenv set .ddev/.env.web --otel-exporter-otlp-logs-endpoint="http://grafana-alloy:4318/v1/logs" > /dev/null 2>&1
-  # - ddev dotenv set .ddev/.env.web --otel-traces-exporter=console > /dev/null 2>&1
+  - ddev dotenv set .ddev/.env.web --otel-exporter-otlp-endpoint="http://grafana-alloy:4317" > /dev/null 2>&1
+  - ddev dotenv set .ddev/.env.web --otel-exporter-otlp-protocol="grpc" > /dev/null 2>&1
 
 ddev_version_constraint: '>= v1.24.3'


### PR DESCRIPTION
## The Issue

The previous configuration relied on the OTLP HTTP exporter, which was not effectively transmitting traces to Tempo. Additionally, the required gRPC extension for PHP was missing, preventing the application from properly utilizing gRPC for OTLP trace exports.

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue

This PR ensure that the application utilizes gRPC for OTLP trace exports, with the correct endpoint and protocol, enabling successful transmission of traces to Tempo.

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

```bash
ddev add-on get https://github.com/tyler36/ddev-site-metrics-laravel/tarball/refs/pull/REPLACE_ME_WITH_THIS_PR_NUMBER/head
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
